### PR TITLE
fastboot: store SN by char16

### DIFF
--- a/plat/hikey/hikey_private.h
+++ b/plat/hikey/hikey_private.h
@@ -77,6 +77,8 @@ extern int flush_loader_image(void);
 extern int flush_user_images(char *cmdbuf, unsigned long addr,
 			     unsigned long length);
 extern int flush_random_serialno(unsigned long addr, unsigned long length);
+extern int ascii_str_to_unicode_str(char *ascii_str, void *unicode_str);
+extern int unicode_str_to_ascii_str(void *unicode_str, char *ascii_str);
 extern void generate_serialno(struct random_serial_num *random);
 extern int assign_serialno(char *cmdbuf, struct random_serial_num *random);
 extern char *load_serialno(void);

--- a/plat/hikey/plat_io_storage.c
+++ b/plat/hikey/plat_io_storage.c
@@ -72,6 +72,8 @@ static const io_dev_connector_t *dw_mmc_dev_con;
 static struct block_ops dw_mmc_ops;
 static uintptr_t emmc_dev_handle;
 
+static char sn_str[32];
+
 #define SPARSE_FILL_BUFFER_ADDRESS	0x18000000
 #define SPARSE_FILL_BUFFER_SIZE		0x08000000
 
@@ -621,7 +623,12 @@ char *load_serialno(void)
 	if (random->magic != RANDOM_MAGIC)
 		return NULL;
 
-	return random->serialno;
+	result = unicode_str_to_ascii_str(random->serialno, sn_str);
+	if (result) {
+		NOTICE("Invalid serial number\n");
+		return NULL;
+	}
+	return sn_str;
 exit:
 	io_close(img_handle);
 	return NULL;


### PR DESCRIPTION
Since UEFI stores serial number by CHAR16 type, and ATF stores
serial number by CHAR8 type. It causes incompatible issue.

Now force ATF to store serial number by CHAR16 type.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>