### PR TITLE
hikey: migrate to bl2_el3

### DIFF
--- a/plat/hikey/bl1_plat_setup.c
+++ b/plat/hikey/bl1_plat_setup.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2014-2015, Linaro Ltd and Contributors. All rights reserved.
- * Copyright (c) 2014-2015, Hisilicon Ltd and Contributors. All rights reserved.
+ * Copyright (c) 2014-2018, Linaro Ltd and Contributors. All rights reserved.
+ * Copyright (c) 2014-2018, Hisilicon Ltd and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -228,7 +228,6 @@ void bl1_platform_setup(void)
 	io_setup();
 	get_partition();
 	NOTICE("Enter fastboot mode...\n");
-	flush_loader_image();
 	hikey_verify_serialno(&random);
 	usb_download();
 }

--- a/plat/hikey/hikey_private.h
+++ b/plat/hikey/hikey_private.h
@@ -73,7 +73,6 @@ void configure_mmu_el3(unsigned long total_base,
 		       unsigned long ro_limit,
 		       unsigned long coh_start,
 		       unsigned long coh_limit);
-extern int flush_loader_image(void);
 extern int flush_user_images(char *cmdbuf, unsigned long addr,
 			     unsigned long length);
 extern int flush_random_serialno(unsigned long addr, unsigned long length);

--- a/plat/hikey/partitions.c
+++ b/plat/hikey/partitions.c
@@ -131,9 +131,16 @@ static int parse_entry(uintptr_t buf)
 static void create_dummy_entry(void)
 {
 	int bytes;
+
+	entries = 0;
 	ptable[entries].start = 0;
 	ptable[entries].length = 0;
 	bytes = sprintf(ptable[entries].name, "ptable");
+	ptable[entries].name[bytes] = '\0';
+	entries++;
+	ptable[entries].start = 0;
+	ptable[entries].length = 0;
+	bytes = sprintf(ptable[entries].name, "loader");
 	ptable[entries].name[bytes] = '\0';
 	entries++;
 }


### PR DESCRIPTION
Since non-TF ROM is used in HiKey (Hi6220 SoC), BL2_EL3 is designed
for this case. Then user won't touch BL1 any more in normal boot
case. BL1 only exists in recovery mode.

Recovery Mode:
  BL1 + NS BL1U
Normal Boot Mode:
  BL2_EL3 + BL2 + SCP_BL2 + BL31 + BL32 + BL33

In original mode, fastboot binary flush itself into Boot Area in eMMC.
Now create a new dummy partition entry "loader" in HiKey after migrating
to BL2_EL3.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>