### PR TITLE
fastboot: handle erase command

### DIFF
--- a/plat/hikey/hikey_private.h
+++ b/plat/hikey/hikey_private.h
@@ -75,6 +75,8 @@ void configure_mmu_el3(unsigned long total_base,
 		       unsigned long coh_limit);
 extern int flush_user_images(char *cmdbuf, unsigned long addr,
 			     unsigned long length);
+extern int erase_partitions(char *cmdbuf, unsigned long addr,
+			    unsigned long length);
 extern int flush_random_serialno(unsigned long addr, unsigned long length);
 extern int ascii_str_to_unicode_str(char *ascii_str, void *unicode_str);
 extern int unicode_str_to_ascii_str(void *unicode_str, char *ascii_str);

--- a/plat/hikey/usb.c
+++ b/plat/hikey/usb.c
@@ -1402,6 +1402,13 @@ static void fb_reboot(char *cmdbuf)
 	panic();
 }
 
+static void fb_erase(char *cmdbuf)
+{
+	erase_partitions(cmdbuf + 6, FB_DOWNLOAD_BASE, FB_MAX_FILE_SIZE);
+	tx_status("OKAY");
+	rx_cmd();
+}
+
 static void usb_rx_cmd_complete(unsigned actual, int stat)
 {
 	if(stat != 0) return;
@@ -1424,8 +1431,7 @@ static void usb_rx_cmd_complete(unsigned actual, int stat)
 		return;
 	} else if(memcmp(cmdbuf, (void *)"erase:", 6) == 0) {
                 /* FIXME erase is not supported but we return success */
-                tx_status("OKAY");
-                rx_cmd();
+		fb_erase(cmdbuf);
                 return;
 	} else if(memcmp(cmdbuf, (void *)"flash:", 6) == 0) {
 		INFO("recog updatefile\n");


### PR DESCRIPTION
Erase data on specified partition. The erase option is implemented
by write option.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>