### PR TITLE
hikey: increase the BL1 RO region

### DIFF
--- a/plat/hikey/include/platform_def.h
+++ b/plat/hikey/include/platform_def.h
@@ -119,9 +119,9 @@
  * BL1 RW data is relocated from ROM to RAM at runtime so we need 2 base
  * addresses.
  ******************************************************************************/
-#define BL1_RO_BASE			(0xf9818000)
+#define BL1_RO_BASE			(0xf9828000)
 #define BL1_RO_LIMIT			(BL1_RO_BASE + 0x10000)
-#define BL1_RW_BASE			(BL1_RO_LIMIT)	/* 0xf982_8000 */
+#define BL1_RW_BASE			(BL1_RO_LIMIT)	/* 0xf983_8000 */
 #define BL1_RW_SIZE			(0xf9898000 - BL1_RW_BASE)
 #define BL1_RW_LIMIT			(0xf9898000)
 


### PR DESCRIPTION
When TBB is enabled in ARM Trusted Firmware, need to increase
the size of BL1 RO region.

Signed-off-by: Teddy Reed <teddy@prosauce.org>
Signed-off-by: Victor Chong <victor.chong@linaro.org>
Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>